### PR TITLE
Upgrade GitHub actions gradle/actions/* to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Execute Gradle build
         run: ./gradlew build

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -7,4 +7,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.1
-      - uses: gradle/wrapper-validation-action@v2.0.0
+      - uses: gradle/actions/wrapper-validation@v4


### PR DESCRIPTION
`gradle/wrapper-validation-action@v2.0.0` is outdated and seems to randomly fail sometimes.

Also, it is included in [`gradle/actions/setup-gradle@v4`](https://github.com/gradle/actions/tree/main/wrapper-validation#the-wrapper-validation-action), so it can even be deleted if `gradle/actions/setup-gradle` is upgraded.